### PR TITLE
Enhance header accessibility by adding aria-labels to buttons

### DIFF
--- a/.idx/dev.nix
+++ b/.idx/dev.nix
@@ -1,0 +1,27 @@
+{pkgs}: {
+  channel = "stable-24.05";
+  packages = [
+    pkgs.nodejs_20
+  ];
+  idx.extensions = [
+    "angular.ng-template"
+  ];
+  idx.previews = {
+    previews = {
+      web = {
+        command = [
+          "npm"
+          "run"
+          "start"
+          "--"
+          "--port"
+          "$PORT"
+          "--host"
+          "0.0.0.0"
+          "--disable-host-check"
+        ];
+        manager = "web";
+      };
+    };
+  };
+}

--- a/angular.json
+++ b/angular.json
@@ -92,5 +92,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -63,14 +63,14 @@
       } @loading {
       <div class="h-2.5 bg-gray-300 rounded-full dark:bg-gray-600 w-32"></div>
       }
-      <button type="button" (click)="toggleTheme()">
+      <button type="button" (click)="toggleTheme()" aria-label="Cambiar tema">
         @if(darkTheme){
           <app-sun-icon className="w-6"/>
         } @else {
           <app-moon-icon className="w-6"/>
         }
       </button>
-      <button type="button" class="md:hidden" [class.hidden]="visibleMenu" (click)="toggleMenu()">
+      <button type="button" class="md:hidden" [class.hidden]="visibleMenu" (click)="toggleMenu()" aria-label="Abrir menú">
         <app-menu-icon/>
       </button>
     </div>


### PR DESCRIPTION

## Summary  
Improved the accessibility of the header by adding `aria-labels` to buttons, ensuring better screen reader support.

## Before & After  
### Before 
![image](https://github.com/user-attachments/assets/8e9dd848-0516-45f0-ac2c-ee5388522661)

### After
![image](https://github.com/user-attachments/assets/88b1db22-c62a-4386-8f75-2b58ef85a63d)
