### PR TITLE
feat: improve keyboard navigation in navbar

### DIFF
--- a/src/app/sections/header/header.component.html
+++ b/src/app/sections/header/header.component.html
@@ -16,6 +16,7 @@
         <ul class="select-none flex flex-col md:flex-row justify-center items-center gap-8 h-lvh md:h-auto ">
           <li>
             <a #navLink 
+              role="link" tabindex="0" (keydown)="onKeydown($event, 'hero')"
               (click)="onSectionSelect('hero')" 
               class="nav-link cursor-pointer" 
               [class.active]="activeSection === 'hero'">
@@ -24,6 +25,7 @@
           </li>
           <li>
             <a #navLink 
+              role="link" tabindex="0" (keydown)="onKeydown($event, 'projects')"
               (click)="onSectionSelect('projects')" 
               class="nav-link cursor-pointer"
               [class.active]="activeSection === 'projects'">
@@ -32,6 +34,7 @@
           </li>
           <li>
             <a #navLink 
+              role="link" tabindex="0" (keydown)="onKeydown($event, 'about')"
               (click)="onSectionSelect('about')" 
               class="nav-link cursor-pointer"
               [class.active]="activeSection === 'about'">

--- a/src/app/sections/header/header.component.ts
+++ b/src/app/sections/header/header.component.ts
@@ -94,6 +94,12 @@ export class HeaderComponent implements AfterViewChecked, OnChanges{
     }
   }
 
+  onKeydown(event: KeyboardEvent, section: string) {
+    if (event.key === 'Enter' || event.key === ' ') {
+      this.onSectionSelect(section);
+    }
+  }
+
   public updateActiveSection(sectionId: string): void {
     this.activeSection = sectionId;
   }


### PR DESCRIPTION
## Summary
- Use `role="link"` instead of `href` for section navigation  
- Add `tabindex="0"` to make links focusable  
- Handle `keydown` (Enter, Space) for keyboard navigation  
- Keep smooth scrolling behavior  

## Before & After
Before
- SEO
![image](https://github.com/user-attachments/assets/0e776cb5-2b02-4c44-8923-72437ee6b00d)

- Keyboard Navigation
![image](https://github.com/user-attachments/assets/af29108b-b22e-4d01-82c2-be48f9e9ecb6)

After
- SEO
![image](https://github.com/user-attachments/assets/4ceaab94-28cc-47ae-937e-2315e44d8391)

- Keyboard Navigation
![image](https://github.com/user-attachments/assets/87ed422f-316f-430c-8583-184225e31c67)
